### PR TITLE
fix: remove unused encryption param from StrategyInstanceRepository (CS9113)

### DIFF
--- a/src/rvs.AlgoTrader.Infrastructure/Repositories/StrategyInstanceRepository.cs
+++ b/src/rvs.AlgoTrader.Infrastructure/Repositories/StrategyInstanceRepository.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using rvs.AlgoTrader.Application.Services;
 using rvs.AlgoTrader.Domain.Entities;
 using rvs.AlgoTrader.Domain.Enums;
 using rvs.AlgoTrader.Infrastructure.Persistence;
@@ -8,7 +7,6 @@ namespace rvs.AlgoTrader.Infrastructure.Repositories;
 
 public class StrategyInstanceRepository(
     AlgoTraderDbContext db,
-    IFieldEncryptionService encryption,
     Domain.Interfaces.IClock clock) : IStrategyInstanceRepository
 {
     public async Task<StrategyInstance?> GetByIdAsync(Guid id, CancellationToken ct = default)
@@ -43,17 +41,12 @@ public class StrategyInstanceRepository(
 
     public async Task AddAsync(StrategyInstance instance, CancellationToken ct = default)
     {
-        // Create the runtime state for this new strategy instance.
         var runtimeState = StrategyRuntimeState.Create(instance.Id, clock.NowInstant());
         instance.RuntimeState = runtimeState;
 
-        // NOTE: BrokerCredential is NOT auto-created here anymore.
+        // NOTE: BrokerCredential is NOT created here.
         // broker_credentials is now an independent table keyed by broker_name.
-        // The credential for this instance's broker must already exist in broker_credentials
-        // (seeded by Migration 020 or inserted via the Broker management API).
-        // To look up the credential at runtime, use:
-        //   IBrokerTimezoneResolver.ResolveAsync(instance.BrokerName)
-        // or query db.BrokerCredentials.FindAsync(instance.BrokerName)
+        // Credential must already exist — seeded by Migration 020 or via the Broker API.
 
         await db.StrategyInstances.AddAsync(instance, ct);
         await db.SaveChangesAsync(ct);


### PR DESCRIPTION
## Fix

**Error:** `CS9113 — Parameter 'encryption' is unread` in `StrategyInstanceRepository.cs` line 11

**Root cause:** `IFieldEncryptionService encryption` was injected into `StrategyInstanceRepository` solely to encrypt/decrypt `BrokerCredential.BrokerToken` when loading/saving strategy instances. Since PR #219/#220 decoupled `BrokerCredential` from `StrategyInstance`, the repository no longer touches credentials at all — making `encryption` a dead parameter.

**Fix:** Removed `IFieldEncryptionService` from the primary constructor. The `using` for `rvs.AlgoTrader.Application.Services` is also removed as it's no longer needed.

> Note: `IFieldEncryptionService` is still correctly used in `BrokerCredentialRepository` (or equivalent) where broker tokens are actually stored — this removal only affects `StrategyInstanceRepository`.